### PR TITLE
ES6 example

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "webpack-dev-server": "^1.10.1"
   },
   "dependencies": {
+    "babel-runtime": "^5.7.0",
     "es5-shim": "^4.1.7",
     "normalize.css": "^3.0.3",
     "react": "^0.13.3"

--- a/src/application.jsx
+++ b/src/application.jsx
@@ -1,3 +1,7 @@
+// Manually load ES5 Compat.
+import 'es5-shim/es5-shim'
+import 'es5-shim/es5-sham'
+
 import React from "react"
 import TodoApp from "components/TodoApp"
 

--- a/src/components/TodoApp.jsx
+++ b/src/components/TodoApp.jsx
@@ -1,9 +1,9 @@
 import "normalize.css";
 import "../styles/style";
 
-import React from "react"
-import content from "./content"
-import ES6Component from 'components/examples/ES6Component'
+import React from "react";
+import content from "./content";
+import ES6Component from "components/examples/ES6Component";
 
 export default class TodoApp extends React.Component {
 

--- a/src/components/TodoApp.jsx
+++ b/src/components/TodoApp.jsx
@@ -3,6 +3,7 @@ import "../styles/style";
 
 import React from "react"
 import content from "./content"
+import ES6Component from 'components/examples/ES6Component'
 
 export default class TodoApp extends React.Component {
 
@@ -32,6 +33,7 @@ export default class TodoApp extends React.Component {
         {this.state.msg} {this.state.date}
         <br />
         {this.state.title}
+        <ES6Component title="Test" initialCount={ 123 } />
       </div>
     )
   }

--- a/src/components/examples/ES6Component.jsx
+++ b/src/components/examples/ES6Component.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from "react";
 
 export default class ES6Component extends React.Component {
 
@@ -8,7 +8,7 @@ export default class ES6Component extends React.Component {
   }
 
   static defaultProps = {
-    title: 'Default title'
+    title: "Default title"
   }
 
   state = {
@@ -17,18 +17,18 @@ export default class ES6Component extends React.Component {
 
   render() {
     return (
-      <div style={{ padding: '10px', border: '1px solid black' }}>
-        <div style={{ fontWeight: 'bold' }}>ES6Component ({ this.props.title })</div>
+      <div style={{ padding: "10px", border: "1px solid black" }}>
+        <div style={{ fontWeight: "bold" }}>ES6Component ({ this.props.title })</div>
         <div>Click Count: { this.state.count }</div>
         <button onClick={ this.handleClick }>Click</button>
       </div>
-    )
+    );
   }
 
   handleClick = (event) => {
-    event.preventDefault()
+    event.preventDefault();
     this.setState({
       count: this.state.count + 1
-    })
+    });
   }
 }

--- a/src/components/examples/ES6Component.jsx
+++ b/src/components/examples/ES6Component.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+export default class ES6Component extends React.Component {
+
+  static propTypes = {
+    title: React.PropTypes.string,
+    initialCount: React.PropTypes.number
+  }
+
+  static defaultProps = {
+    title: 'Default title'
+  }
+
+  state = {
+    count: this.props.initialCount || 0
+  }
+
+  render() {
+    return (
+      <div style={{ padding: '10px', border: '1px solid black' }}>
+        <div style={{ fontWeight: 'bold' }}>ES6Component ({ this.props.title })</div>
+        <div>Click Count: { this.state.count }</div>
+        <button onClick={ this.handleClick }>Click</button>
+      </div>
+    )
+  }
+
+  handleClick = (event) => {
+    event.preventDefault()
+    this.setState({
+      count: this.state.count + 1
+    })
+  }
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -44,16 +44,9 @@ module.exports = {
         test: /\.sass$/,
         loader: "style!css!sass?indentedSyntax"
       }, {
-        test: require.resolve("react"),
-        loader: "imports",
-        query: {
-          shim: "es5-shim/es5-shim",
-          sham: "es5-shim/es5-sham"
-        }
-      }, {
         test: /\.(js|jsx)$/,
         exclude: /(node_modules)/,
-        loader: "babel"
+        loader: "babel?optional[]=runtime&stage=0"
       }
     ]
   }


### PR DESCRIPTION
You'll need to `npm install` after pulling/merging this.

 * Installed `babel-runtime` to give us in-browser classes and all that jazz. Basically this is similar to the JS that coffeescript would inject.
 * Moved the ES5 Shim stuff into the entrypoint, because it's not only React that'll need it.
 * Created `ES6Component` with the latest and greatest syntax -- this stuff may change in the future once ES2015/ES7 etc. gets locked down more.
 * Added `?optional[]=runtime&stage=0` to the babel loader to tell it we want the latest and greatest non-standard shit.